### PR TITLE
Fix: chainstate.cc:82: int main(int, char**): Assertion `status.ok()' failed

### DIFF
--- a/chainstate.cc
+++ b/chainstate.cc
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 
     bool ret;
 
-    options.create_if_missing = false;
+    options.create_if_missing = true;
 
     // Can be found in src/chainparams.cpp, base58Prefixes
     prefix_t prefixes[] = {
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
         }
     }
 
-    leveldb::Status status = leveldb::DB::Open(options, "state", &db);
+    leveldb::Status status = leveldb::DB::Open(options, "./state", &db);
     assert(status.ok());
 
     // Getting obfuscation key


### PR DESCRIPTION
I was able to resolve the below error message by making some minor changes to chainstate.cc before building with make
```
chainstate: chainstate.cc:82: int main(int, char**): Assertion `status.ok()' failed.
```

**Steps**
Open chainstate.cc with your preferred text editor.


Change line 40 from
```c++
options.create_if_missing = false;
```
to
```c++
options.create_if_missing = true;
```
___
Change line 81 from
```c++
leveldb::Status status = leveldb::DB::Open(options, "state", &db);
```
to
```c++
leveldb::Status status = leveldb::DB::Open(options, "./state", &db);
```

Then follow the normal build instructions using make
___

I tested this configuration using a chainstate export from last night and validated the results with success, balances were accurate.

The only issue I observed was cosmetic, high balances are formatted in scientific notation (extract of my export below)

```
16ftSEQ4ctQFDtVZiUBusQUjRrGhM3JYwe;1.68791e+13
3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r;1.65583e+13
16rCmCmbuWDhPjWTrpQGaU3EPdZF7MTdUk;1.07203e+13
3Cbq7aT1tY8kMxWLbitaG7yT6bPbKChq64;9.80425e+12
3Nxwenay9Z8Lc9JBiywExpnEFiLp6Afp8v;9.78483e+12
183hmJGRuTEi2YDCWy5iozY8rZtFwVgahM;8.59472e+12
```

Can anyone else test this and confirm your results?


